### PR TITLE
Change scrolling for sticky from `window.scrollBy` to an offset

### DIFF
--- a/action_helpers/browser_side_scripts.js
+++ b/action_helpers/browser_side_scripts.js
@@ -247,20 +247,6 @@ var browserSideFind = function(locators, opt_options) {
       var maybeDisplayed = all.filter(isMaybeDisplayed);
       if (maybeDisplayed.length === 1 && shouldAutoScroll(maybeDisplayed[0])) {
         scrollToHtmlElement(maybeDisplayed[0]);
-        // Sticky headers can stack so get all active and compute total height.
-        var stickyHeaders = document.querySelectorAll('[data-testing="sticky-header"]');
-        var stickyHeaderTotalHeight = 0;
-        stickyHeaders.forEach(function(stickyHeader) {
-          const headerHeight = stickyHeader.getBoundingClientRect().height;
-          stickyHeaderTotalHeight += headerHeight;
-        });
-        if (stickyHeaderTotalHeight &&
-          maybeDisplayed[0].getBoundingClientRect().top < stickyHeaderTotalHeight) {
-          var scrollY = window.scrollY;
-          if (scrollY) {
-            window.scroll(0, scrollY - stickyHeaderTotalHeight);
-          }
-        }
         if (hasCorrectDisplayStatus(maybeDisplayed[0])) {
           candidateElements = maybeDisplayed;
         }
@@ -799,13 +785,20 @@ var browserSideFind = function(locators, opt_options) {
         targetRight = _a.right,
         targetBottom = _a.bottom,
         targetLeft = _a.left;
+    // Sticky headers can stack so get all active and compute total height.
+    var stickyHeaders = document.querySelectorAll('[data-testing="sticky-header"]');
+    var stickyHeaderTotalHeight = 0;
+    stickyHeaders.forEach(function(stickyHeader) {
+      const headerHeight = stickyHeader.getBoundingClientRect().height;
+      stickyHeaderTotalHeight += headerHeight;
+    });
     // These values mutate as we loop through and generate scroll coordinates
     var targetBlock =
         block === 'start' || block === 'nearest'
-            ? targetTop
+            ? targetTop - stickyHeaderTotalHeight
             : block === 'end'
-                ? targetBottom
-                : targetTop + targetHeight / 2; // block === 'center
+                ? targetBottom - stickyHeaderTotalHeight
+                : (targetTop - stickyHeaderTotalHeight) + targetHeight / 2; // block === 'center
     var targetInline =
         inline === 'center'
             ? targetLeft + targetWidth / 2


### PR DESCRIPTION
This diff fixes an issue where an element cannot be scrolled into view properly with a sticky element.

The cause for this appears to be `window.scrollBy` not working (I think maybe because it keeps trying to scroll back to the original spot on a retry?).

To alleviate this, an offset has been applied for `targetBlock`.