### PR TITLE
Fix tag name locator

### DIFF
--- a/action_helpers/browser_side_scripts.js
+++ b/action_helpers/browser_side_scripts.js
@@ -1032,6 +1032,8 @@ var browserSideLocator = function(locator) {
     return {using: 'regexp', value: locator.toString()};
   if (locator && (locator.using == 'css selector' || locator.using == 'xpath'))
     return {using: locator.using, value: locator.value};
+  if (locator && (locator.using == 'tag name'))
+    return {using: 'css selector', value: locator.value};
   throw new Error(
       'Only text, number, RegExp, by.css() and by.xpath() are supported by ' +
       'helpers, sorry: ' + locator);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freelancercom/blue-harvest",
-  "version": "0.3.1-fork.37",
+  "version": "0.3.1-fork.38",
   "description": "protractor helpers",
   "scripts": {
     "tsc": "tsc",


### PR DESCRIPTION
Newer versions of `selenium-webdriver` changed `locator.using` to `tag name` instead of `css selector` when using `By.tagName()`, but the underlying implementation hasn't changed and is just using `return By.css(...)`.